### PR TITLE
[Fix] Trimmed leading and trailing whitespace for AddItemForm input

### DIFF
--- a/src/components/TruthTally/AddItemForm.js
+++ b/src/components/TruthTally/AddItemForm.js
@@ -36,7 +36,7 @@ const AddItemForm = (props) => {
     });
 
     if (!dupe && input) {
-      handleAddItem(itemInput.current.value.replace(/(^|\s)[a-z]/g, (f) => f.toUpperCase()));
+      handleAddItem(itemInput.current.value.trim().replace(/(^|\s)[a-z]/g, (f) => f.toUpperCase()));
       e.currentTarget.reset();
       return;
     }


### PR DESCRIPTION
### Description

The AddItemForm component text input was not trimming leading/trailing whitespace. This resulted in failing validation on the backend. 

This fix trims the leading/trailing whitespace from text entries in the AddItemForm text input.