### PR TITLE
[Fix] Added condition in add_list to check if input.tags is empty

### DIFF
--- a/netlify/functions/add_list/add_list.js
+++ b/netlify/functions/add_list/add_list.js
@@ -128,7 +128,7 @@ const handler = async (event) => {
       const database = await connectToDatabase(process.env.MONGODB_URI);
       const collection = database.collection(process.env.MONGODB_COLLECTION);
       let newURI = randomstring.generate(8);
-      const tags = input.tags.map((tag) => tag.toLowerCase());
+      const tags = input.tags && input.tags.length > 0 ? input.tags.map((tag) => tag.toLowerCase()) : [];
       await collection.insertOne({
         [newURI]: input.items,
         views: 0,


### PR DESCRIPTION
### Description

A bug was introduced in #16 which causes the payload to fail validation when trying to add a list with no tags. This PR fixes this by adding a condition in the `add_list` backend function to check for the presence of `input.tags` and that the length is greater than 0. If so, then a new array is created which converts the tags in the array to lowercase.