### PR TITLE
[Feature] Addition of unranked list authors when sharing

### DIFF
--- a/netlify/functions/add_list/add_list.js
+++ b/netlify/functions/add_list/add_list.js
@@ -132,14 +132,14 @@ const handler = async (event) => {
       await collection.insertOne({
         uri: newURI,
         items: input.items,
-        views: 0,
-        rating: 0,
         title: input.title,
+        ...(input.author && { author: input.author }),
         type: input.type.toLowerCase(),
         unlisted: input.unlisted,
-        ...(input.author && { author: input.author }),
         ...(input.tags && input.tags.length > 0 && { tags: tags }),
-        ...(input.source_uri && { source_uri: input.source_uri })
+        ...(input.source_uri && { source_uri: input.source_uri }),
+        views: 0,
+        rating: 0
       });
 
       return {

--- a/src/components/TruthTally/ShareListModal.js
+++ b/src/components/TruthTally/ShareListModal.js
@@ -199,11 +199,12 @@ const ShareListModal = ({
             const type = 'unranked';
             const unlisted = formData.isUnlisted;
             const newList = {
-              items: tempList,
-              unlisted: unlisted,
               title: title,
-              ...(tags.length > 0 && { tags: tags }),
-              type: type
+              ...(author.replace(/\s+/g, '') !== '' && { author: author }),
+              items: tempList,
+              type: type,
+              unlisted: unlisted,
+              ...(tags.length > 0 && { tags: tags })
             };
 
             try {
@@ -256,12 +257,12 @@ const ShareListModal = ({
             const type = 'unranked';
             const unlisted = formData.isUnlisted;
             const newList = {
-              items: tempList,
-              unlisted: unlisted,
               title: title,
-              ...(tags.length > 0 && { tags: tags }),
+              ...(author.replace(/\s+/g, '') !== '' && { author: author }),
+              items: tempList,
               type: type,
-              ...(author.replace(/\s+/g, '') !== '' && { author: author })
+              unlisted: unlisted,
+              ...(tags.length > 0 && { tags: tags })
             };
             try {
               let results = await fetch('/.netlify/functions/add_list', {
@@ -284,13 +285,13 @@ const ShareListModal = ({
                 const unlisted = formData.isUnlisted;
                 const sourceListURI = unrankedURI;
                 const newList = {
-                  items: tempRankedList,
-                  unlisted: unlisted,
                   title: title,
-                  ...(tags.length > 0 && { tags: tags }),
+                  ...(author.replace(/\s+/g, '') !== '' && { author: author }),
+                  items: tempRankedList,
                   type: type,
+                  unlisted: unlisted,
                   source_uri: sourceListURI,
-                  ...(author.replace(/\s+/g, '') !== '' && { author: author })
+                  ...(tags.length > 0 && { tags: tags })
                 };
 
                 try {
@@ -372,13 +373,13 @@ const ShareListModal = ({
             isSourceListRanked ? (source_uri = sourceListURI) : (source_uri = uri);
 
             const newList = {
-              items: tempRankedList,
-              unlisted: unlisted,
               title: title,
-              ...(tags.length > 0 && { tags: tags }),
+              ...(author.replace(/\s+/g, '') !== '' && { author: author }),
+              items: tempRankedList,
               type: type,
+              unlisted: unlisted,
               source_uri: source_uri,
-              ...(author.replace(/\s+/g, '') !== '' && { author: author })
+              ...(tags.length > 0 && { tags: tags })
             };
 
             try {
@@ -514,30 +515,27 @@ const ShareListModal = ({
           )}
           <div>
             <form onSubmit={(e) => shareList(e)}>
-              {finishedGameState && (
-                <>
-                  <span style={{ marginRight: 'auto', paddingLeft: '20px' }}>
-                    <label htmlFor="input">Your name:</label>
-                    <FontAwesomeIcon
-                      className="info-icon"
-                      data-tooltip-id="authorTooltip"
-                      data-tooltip-place="top"
-                      icon={faInfoCircle}
-                      data-tooltip-content="Name: Enter your name or a nickname to display as the person who ranked the list when sharing ranked lists with others."
-                    />
-                    <ReactTooltip id="authorTooltip" effect="solid" multiline={true} className="tooltip" />
-                  </span>
-                  <input
-                    type="text"
-                    id="input"
-                    maxLength="30"
-                    name="listAuthor"
-                    placeholder="(optional)"
-                    onChange={handleChange}
-                    value={formData.listAuthor}
-                  />
-                </>
-              )}
+              <span style={{ marginRight: 'auto', paddingLeft: '20px' }}>
+                <label htmlFor="input">Your name:</label>
+                <FontAwesomeIcon
+                  className="info-icon"
+                  data-tooltip-id="authorTooltip"
+                  data-tooltip-place="top"
+                  icon={faInfoCircle}
+                  data-tooltip-content="Name: Enter your name or a nickname to display as the person who created or ranked the list when sharing unranked or ranked lists with others."
+                />
+                <ReactTooltip id="authorTooltip" effect="solid" multiline={true} className="tooltip" />
+              </span>
+              <input
+                type="text"
+                id="input"
+                maxLength="30"
+                name="listAuthor"
+                placeholder="(optional)"
+                onChange={handleChange}
+                value={formData.listAuthor}
+              />
+
               <span style={{ marginRight: 'auto', paddingLeft: '20px' }}>
                 <label htmlFor="input">Tags:</label>
                 <FontAwesomeIcon
@@ -545,7 +543,7 @@ const ShareListModal = ({
                   data-tooltip-id="tagsTooltip"
                   data-tooltip-place="top"
                   icon={faInfoCircle}
-                  data-tooltip-content="Tags: Enter keywords separated by commas to improve searchability and help others discover your list."
+                  data-tooltip-content="Tags: Add up to 6 tags, using single words without spaces and up to 20 characters each, to improve searchability and aid others in discovering your list."
                 />
                 <ReactTooltip id="tagsTooltip" effect="solid" multiline={true} className="tooltip" />
               </span>
@@ -553,11 +551,10 @@ const ShareListModal = ({
                 type="text"
                 id="input"
                 name="listTags"
-                placeholder={'(Optional)'}
+                placeholder={'(optional)'}
                 onChange={handleChange}
                 value={formData.listTags}
               />
-
               <span>
                 <input
                   type="checkbox"

--- a/src/components/TruthTally/TruthTally.js
+++ b/src/components/TruthTally/TruthTally.js
@@ -34,6 +34,7 @@ function TruthTally() {
   const [sourceListTitle, setSourceListTitle] = useState();
   const [sourceListType, setSourceListType] = useState();
   const [sourceListURI, setSourceListURI] = useState();
+  const [sourceListAuthor, setSourceListAuthor] = useState();
   const [sourceRankedListChanged, setSourceRankedListChanged] = useState(false);
   const [sourceTitleChanged, setSourceTitleChanged] = useState(false);
   const [titleInput, setTitleInput] = useState();
@@ -125,6 +126,7 @@ function TruthTally() {
           setListTitle(results.title);
           setSourceItemsList([]);
           setListAuthor();
+          setSourceListAuthor(results.author);
           setSourceListURI(results.source_uri);
           setIsRankingSharedList(false);
           setSourceListTags(results.tags);
@@ -332,6 +334,8 @@ function TruthTally() {
     setSourceRankedListChanged,
     sourceListURI,
     setSourceListURI,
+    sourceListAuthor,
+    setSourceListAuthor,
     listAuthor,
     setListAuthor,
     draggableListItems,
@@ -390,6 +394,9 @@ function TruthTally() {
             }}
             title={isListEditMode ? 'Click to edit' : null}>
             <h3>{listTitle}</h3>
+            {startGameState && !sourceListChanged && !sourceTitleChanged && !isListEditMode && (
+              <h5>created by: {sourceListAuthor}</h5>
+            )}
           </div>
         )}
 

--- a/src/components/TruthTally/index.css
+++ b/src/components/TruthTally/index.css
@@ -333,6 +333,10 @@ form {
   margin: 10px 0px 10px 0px;
 }
 
+.list-title h5 {
+  margin: 2px;
+}
+
 .ranked-list-title h3 {
   margin: 3px 10px 18px 10px;
 }


### PR DESCRIPTION
### Description
Previously the ability to add your name when sharing was restricted to ranked lists, to display "Ranked by {listAuthor}".

This PR adds the ability to add your name when sharing unranked lists. Shared unranked lists will now display "Created by {listAuthor}" if there is one, and will only display so as long as the unranked list is not modified.

Other changes include:
- Updated tooltips to reflect requirements of tags
- Updated data order when submitting new lists