### PR TITLE
[Fix] Update conditions when Rank Again button appears

### DIFF
--- a/components/TruthTally/Controls.js
+++ b/components/TruthTally/Controls.js
@@ -237,7 +237,7 @@ const Controls = (props) => {
           <button onClick={() => startOver()}>Start Over</button>
         ) : null}
 
-        {finishedGameState && !showLoadingScreen && !isPreload && (isSourceListNew || sourceRankedListChanged) ? (
+        {!showLoadingScreen && !isPreload && inProgressGameState ? (
           <button onClick={() => rankAgain()}>Rank Again</button>
         ) : null}
 


### PR DESCRIPTION
### Description

Currently when a user shares a ranked list, and you click "Rank this list", there is no "Rank again" button to restart the ranking process. This PR ensures the "Rank again" button appears in all relevant scenarios. 
