### PR TITLE
[Fix] Next.js Component Layout Structure

### DIFF
--- a/components/Layout.js
+++ b/components/Layout.js
@@ -1,0 +1,12 @@
+import Header from '@/components/Header';
+
+const Layout = ({ children }) => {
+  return (
+    <div className="main-container">
+      <Header />
+      {children}
+    </div>
+  );
+};
+
+export default Layout;

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -1,4 +1,5 @@
 import Head from 'next/head';
+import Layout from '@/components/Layout';
 import '@/styles/globals.css';
 import 'react-notifications-component/dist/theme.css';
 import 'animate.css/animate.min.css';
@@ -28,7 +29,9 @@ export default function App({ Component, pageProps }) {
 
         <link rel="manifest" href="/manifest.json" />
       </Head>
-      <Component {...pageProps} />
+      <Layout>
+        <Component {...pageProps} />
+      </Layout>
     </>
   );
 }

--- a/pages/_document.js
+++ b/pages/_document.js
@@ -1,19 +1,14 @@
 import { Html, Head, Main, NextScript } from 'next/document';
 
-import Header from '@/components/Header';
-
 export default function Document() {
   return (
     <Html lang="en">
       <Head />
 
       <body>
-        <div className="main-container">
-          <Header />
-          <Main />
+        <Main />
 
-          <NextScript />
-        </div>
+        <NextScript />
       </body>
     </Html>
   );

--- a/pages/list/[uri].js
+++ b/pages/list/[uri].js
@@ -29,9 +29,7 @@ const TruthTallyURI = ({ uri, listData }) => {
         <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1" />
       </Head>
 
-      <div className="main-container">
-        <TruthTally uri={uri} listData={listData} />
-      </div>
+      <TruthTally uri={uri} listData={listData} />
     </>
   );
 };

--- a/pages/list/index.js
+++ b/pages/list/index.js
@@ -1,11 +1,7 @@
 import TruthTally from '@/components/TruthTally/';
 
 const TruthTallyIndex = () => {
-  return (
-    <div className="main-container">
-      <TruthTally />
-    </div>
-  );
+  return <TruthTally />;
 };
 
 export default TruthTallyIndex;


### PR DESCRIPTION
### Description

Resolves #24 

This PR will fix the issue with an incompatibility with Next.js that caused the issue reported in #24.

As reported in the issue, the `__next` div injected and required by Next.js was nested within the `main-container` div due an incompatible structuring. To fix this I've created a Layout component that will act as the Layout for all future iterations of Truth Tally. This will also allow for the consistent placement of the header and footer once the site expands to a more traditional site layout for the inclusion of an archive of user created lists.


| Before | After |
|--------|-----|
|<img width="375" alt="image" src="https://user-images.githubusercontent.com/65082164/230250914-16d8f506-4d56-4b8c-9125-8a860ec6e593.png">| <img width="377" alt="image" src="https://user-images.githubusercontent.com/65082164/230250971-7f36fc14-4676-4348-baf1-8c27eedcd6c8.png">|


### Testing Instructions:
1. Open the dev staging URL on a mobile device, once generated below.
2. Test creating a new list and rank, and observe that the issue is resolved.